### PR TITLE
Update DN parsing to support any DN

### DIFF
--- a/lib/main.py
+++ b/lib/main.py
@@ -801,7 +801,7 @@ def main():
     build_filter = input ("Enter target sAMAccountName or distinguishedName: ").lower()
     ldapsearch=magic(ldap_server, ldap_session, domain, logs_dir) 
     while True:
-        if "cn" in build_filter:
+        if "dc=" in build_filter:
             search = "(distinguishedName={})".format(build_filter)
             ldap_filter=search
             logging.info(f'Searching for: {build_filter}')


### PR DESCRIPTION
I attempted to look up a OU DN. It was not detected due to the `cn` parse of the entered query. Changed this to `dc=` as to support any DN format, as a DN will have the domain always (assumingly) mentioned such as `dc=domain,dc=tld`. Also added the equal sign to stop incorrect DN detection such as a username `cnserver`.